### PR TITLE
docs: add necessary step for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ $ yarn add esbuild-webpack-plugin
 ## Test
 
 ```bash
+// Get prepared
+$ yarn && yarn build
+
 // Minify with terser
 $ yarn build:example
 


### PR DESCRIPTION
`build:example:esbuild` would fail without `yarn build`, I could't have figured this out until I take a closer look into the code. Adding this step into readme should help other new comers.

---
PS: `yarn build` successfully omitted files while failed type checking on my side with the following error:
```
yarn run v1.22.4
$ rm -rf dist && tsc -p src
node_modules/@umijs/types/index.d.ts:199:26 - error TS2344: Type 'Html' does not satisfy the constraint 'new (...args: any) => any'.
  Type 'Html' provides no match for the signature 'new (...args: any): any'.

199     { html: InstanceType<Html> }
                             ~~~~
```

It might be an issue of [umi](https://github.com/umijs/umi/) but I did not find anyone reporting this under umi repo.
