### PR TITLE
fix: lock esbuild version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "webpack": "^4.0.0"
   },
   "dependencies": {
-    "esbuild": "^0.6.2"
+    "esbuild": "0.6.5"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"


### PR DESCRIPTION
tnpm `npm_config_registry` not support