### PR TITLE
Add constructor to allow esbuild customizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@
 /test/fixtures/**/.umi
 /test/fixtures/**/dist
 /.umi
-/.idea
-/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /test/fixtures/**/.umi
 /test/fixtures/**/dist
 /.umi
+/.idea
+/.vscode

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use [esbuild](https://github.com/evanw/esbuild) as minifier for webpack.
 ## Install
 
 ```bash
-$ yarn add esbuild-webpack-plugin
+$ yarn add esbuild-webpack-plugin --dev
 ```
 
 ## Webpack config
@@ -20,9 +20,8 @@ const ESBuildPlugin = require('esbuild-webpack-plugin').default;
 module.exports = {
   optimization: {
     minimizer: [
-      new ESBuildPlugin({
-        optimize: true,
-      }),
+      // For plugin options, please refer: https://github.com/evanw/esbuild
+      new ESBuildPlugin({...}),
     ],
   },
 };
@@ -30,17 +29,17 @@ module.exports = {
 
 ## Test
 
-```bash
-// Get prepared
+```shell script
+# Get prepared
 $ yarn && yarn build
 
-// Minify with terser
+# Minify with terser
 $ yarn build:example
 
-// Minify with esbuild
+# Minify with esbuild
 $ yarn build:example:esbuild
 
-// Do not minify
+# Do not minify
 $ yarn build:example:nocompress
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ const ESBuildPlugin = require('esbuild-webpack-plugin').default;
 module.exports = {
   optimization: {
     minimizer: [
-      // For plugin options, please refer: https://github.com/evanw/esbuild
-      new ESBuildPlugin({...}),
+      new ESBuildPlugin(),
+      /**
+       * Or customize ESBuild options like below:
+       *
+       * new ESBuildPlugin({target: "es5"}),
+       *
+       * For details, please refer: https://github.com/evanw/esbuild
+       */
     ],
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
 } from 'esbuild';
 
 export interface ESBuildPluginOptions
-  extends Omit<TransformOptions, 'sourcefile'> {}
+  extends Omit<TransformOptions, 'minify' | 'sourcemap' | 'sourcefile'> {}
 
 export default class ESBuildPlugin {
   private readonly options: ESBuildPluginOptions;
@@ -38,10 +38,10 @@ export default class ESBuildPlugin {
 
     const transform = async () =>
       await ESBuildPlugin.service.transform(source, {
+        ...this.options,
         minify: true,
         sourcemap: !!devtool,
         sourcefile: file,
-        ...this.options,
       });
 
     try {


### PR DESCRIPTION
## Reason

The latest ESBuild uglifies my JavaScript codes into undesired targets, e.g: **ESNext**.
It fails to execute in some old browsers, with some new syntax features, e.g: **nullish coalescing**.

As ESBuild already supports its own options, therefore, I hope this webpack plugin can also pass down the customized options to the ESBuild.

## Changes
- Add constructor options (optional, exported as `ESBuildPluginOptions` interface), to allow esbuild customizations.
Option details can refer to: https://github.com/evanw/esbuild

- Tune class internal typings and make it more normalized.
- Update README on related usages