### PR TITLE
Chore: upgrade esbuild version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "webpack": "^4.0.0"
   },
   "dependencies": {
-    "esbuild": "^0.7.15"
+    "esbuild": "^0.12.15"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"


### PR DESCRIPTION
esbuild@0.7.x 不支持在 m1 芯片（arm64）中运行，需要升级到新版本

Ref: [esbuild changelog](https://github.com/evanw/esbuild/blob/master/CHANGELOG.md#0847)